### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/.AGENTS.md
+++ b/.AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Guidance
+
+This repository contains a full-stack dropshipping store built with Node.js/Express and React. Before proposing changes, read existing code and documentation carefully. Avoid duplicating logic that already exists.
+
+## Key References
+- Project structure and conventions are described in `.kiro/steering/structure.md`.
+- Tech stack details are in `.kiro/steering/tech.md`.
+- Development commands are listed in `CLAUDE.md`.
+- Environment setup instructions are in `README.md`.
+
+## Development Rules
+1. **Reuse Existing Code**: Search the repository before adding new utilities or routes. For example, `services/cartService.js` already provides cart logic – prefer extending it rather than creating new cart helpers.
+2. **Follow Project Conventions**: Routes live under `/routes`, models under `/models`, middleware under `/middleware`, and utilities under `/utils`.
+3. **Logging**: Use the `utils/logger.js` module instead of `console.log` for new logging statements.
+4. **Environment Variables**: Keep secrets and configuration in `.env` as shown in the README. Validate required variables on startup.
+5. **Testing and Linting**: Run `npm test` and `npm run lint:check` before committing. Frontend tests can be run with `cd client && npm test`.
+6. **Security and Validation**: Use the validation helpers in `middleware/security.js` and follow the authentication patterns in `middleware/auth.js`.
+7. **Avoid Committing Build Artifacts**: Do not commit `client/dist`, `coverage/`, or `logs/`. Update `.gitignore` if needed.
+8. **Think Before Coding**: Review existing modules and documentation. Only implement features that are missing or broken. Summarize reasoning in commit messages.
+
+Adhering to these guidelines will keep changes consistent with the current architecture and avoid unnecessary code.


### PR DESCRIPTION
## Summary
- add root `.AGENTS.md` with instructions for Codex

## Testing
- `npm test` *(fails: MongoDB download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68822689dafc832c9cf7f7fc19c7e58f